### PR TITLE
Remove inspect limit for Dialyzer warnings

### DIFF
--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -132,6 +132,8 @@ defmodule Mix.Tasks.Dialyzer do
 
   @default_warnings [:unmatched_returns, :error_handling, :race_conditions, :underspecs, :unknown]
 
+  @inspect_opts [pretty: true, limit: :infinity]
+
   def run(args) do
     {opts, _, []} = OptionParser.parse(args, switches: @switches)
 
@@ -173,9 +175,9 @@ defmodule Mix.Tasks.Dialyzer do
     if Mix.debug?() do
       {ignored, failed} = analysis
       Mix.shell().info("IGNORED WARNINGS:")
-      Mix.shell().info(inspect(ignored, pretty: true))
+      Mix.shell().info(inspect(ignored, @inspect_opts))
       Mix.shell().info("FAILURES:")
-      Mix.shell().info(inspect(failed, pretty: true))
+      Mix.shell().info(inspect(failed, @inspect_opts))
     end
 
     analysis


### PR DESCRIPTION
Hi there 👋

This PR removes the `inspect` limit when using `mix dialyzer` with `MIX_DEBUG=1`.
This makes the `inspect`ing the raw dialyzer warnings consistant with displaying the _human-readable_ warnings, where, however high the number of warnings, they will always all be printed.

Best 🤗 