### PR TITLE
Lots of 1.2 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: elixir
 elixir:
   - '1.5'
   - '1.6'
+  - '1.7'
 otp_release:
   - '19.0'
   - '20.0'
+  - '21.0'
+matrix:
+  exclude:
+    - elixir: '1.5'
+      otp_release: '21.0'

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -309,8 +309,7 @@ defmodule Mix.Tasks.Dialyzer do
   end
 
   defp deps_paths do
-    [env: Mix.env(), include_children: true]
-    |> Mix.Dep.loaded()
+    Mix.Dep.cached()
     |> Enum.reject(fn dep -> dep.opts[:from_umbrella] || dep.opts[:app] == false end)
     |> Enum.flat_map(&Mix.Dep.load_paths/1)
     |> Enum.map(&String.to_charlist/1)

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.Dialyzer do
 
     _ = check_or_build(otp_plt_name(), &otp_app_paths/0, "Erlang/OTP", check, [])
     _ = check_or_build(elixir_plt_name(), &elixir_paths/0, "Elixir", check, [otp_plt_name()])
-    _ = check_or_build(deps_plt_name(), &deps_paths/0, "dependencies", check, [elixir_plt_name()])
+    _ = check_or_build(deps_plt_name(), &deps_paths/0, "dependencies", check, [otp_plt_name(), elixir_plt_name()])
 
     # Run analysis
     # Turns match_pattern into a match_spec that returns true

--- a/lib/mix/tasks/dialyzer.ex
+++ b/lib/mix/tasks/dialyzer.ex
@@ -296,7 +296,7 @@ defmodule Mix.Tasks.Dialyzer do
   defp deps_paths do
     [env: Mix.env(), include_children: true]
     |> Mix.Dep.loaded()
-    |> Enum.reject(fn dep -> dep.opts[:from_umbrella] end)
+    |> Enum.reject(fn dep -> dep.opts[:from_umbrella] || dep.opts[:app] == false end)
     |> Enum.flat_map(&Mix.Dep.load_paths/1)
     |> Enum.map(&String.to_charlist/1)
   end


### PR DESCRIPTION
Please read the individual commits when reviewing, but these are a few breaking changes.

1. Ignoring dependencies with no app file, e.g. things pulled for frontend assets or build considerations.
2. Restructuring the PLT format: we now correctly layer such that we are adding to the PLT on each step. It also seems slightly faster this way.
3. Removing a deprecation warning on Elixir 1.7.
4. Prevent protocol consolidation from breaking analysis (module defined in two different BEAM files).
5. Run the build on 1.7 and OTP 21.